### PR TITLE
Avoid reflection on map entries

### DIFF
--- a/src/valuehash/impl.clj
+++ b/src/valuehash/impl.clj
@@ -82,8 +82,8 @@
 
 (defn- map-entry->byte-array
   [map-entry]
-  (join-byte-arrays [(to-byte-array (.getKey map-entry))
-                     (to-byte-array (.getValue map-entry))]))
+  (join-byte-arrays [(to-byte-array (key map-entry))
+                     (to-byte-array (val map-entry))]))
 
 ;; Collections
 (extend-protocol CanonicalByteArray


### PR DESCRIPTION
This should speed up the library a little bit by avoiding reflection on `java.util.Map$Entry` objects.